### PR TITLE
replaced run-shell-command

### DIFF
--- a/lsystem.lisp
+++ b/lsystem.lisp
@@ -409,7 +409,7 @@ parameter list and t."
   (output-simple-eps (geometry ls) filename
                      :ps-width width
                      :sphere-width sphere-width)
-  (asdf:run-shell-command (format nil "gv ~A -scale 10" filename)))
+  (uiop:run-program (format nil "gv ~A -scale 10" filename)))
 
 (defmethod rewrite-and-raytrace ((ls l-system) filename
                                  &key
@@ -419,7 +419,7 @@ parameter list and t."
   (rewrite ls depth)
   (if (null (geometry ls)) (create-geometry ls))
   (output-povray (geometry ls) filename :width-multiplier width)
-  (asdf:run-shell-command (format nil "povray +i~A" filename)))
+  (uiop:run-program (format nil "povray +i~A" filename)))
 
 (defmethod timed-raytrace ((ls l-system)
                            &key (filename "foo.pov")
@@ -435,7 +435,7 @@ parameter list and t."
   (time (output-povray (geometry ls) filename
                        :width-multiplier width-multiplier))
   (format t "~%Raytracing:~%")
-  (time (asdf:run-shell-command (format nil "povray +i~A" filename))))
+  (time (uiop:run-program (format nil "povray +i~A" filename))))
 
 (defmethod timed-preview ((ls l-system)
                           &key (filename "foo.eps")
@@ -451,7 +451,7 @@ parameter list and t."
   (time (output-simple-eps (geometry ls) filename
                            :ps-width width-multiplier))
   (format t "~%Ghostview:~%")
-  (time (asdf:run-shell-command (print (format nil "gv ~A -scale 10" filename)))))
+  (time (uiop:run-program (print (format nil "gv ~A -scale 10" filename)))))
 
 (defun lsys2eps (classname filename &key (depth nil)
                                       (width-multiplier 0.3))


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```